### PR TITLE
Migration to .NET 6 & 2024 tax codes fixes

### DIFF
--- a/DegiroPitGenerator/DegiroOperationsProvider.cs
+++ b/DegiroPitGenerator/DegiroOperationsProvider.cs
@@ -38,12 +38,12 @@ namespace DegiroPitGenerator
             }
             else
             {
-                var degiroIntegration = await new Integrations.Degiro.IntegrationFactory(_configuration).Create();
+                var degiroIntegration = await new IntegrationFactory(_configuration).Create();
 
-                transactionCsv = degiroIntegration.GetTransactions();
-                cashOperationCsv = degiroIntegration.GetCashOperations(pitYear);
+                transactionCsv = await degiroIntegration.GetTransactionsAsync();
+                cashOperationCsv = await degiroIntegration.GetCashOperationsAsync(pitYear);
             }
-                
+
             var degiroTransactions = transactionCsv.GetRows();
             var degiroCashOperations = cashOperationCsv.GetRows();
 
@@ -55,5 +55,5 @@ namespace DegiroPitGenerator
                 YearFees = _feeAdapter.Adapt(degiroCashOperations)
             };
         }
-    }
+   }
 }

--- a/DegiroPitGenerator/DegiroPitGenerator.csproj
+++ b/DegiroPitGenerator/DegiroPitGenerator.csproj
@@ -2,15 +2,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>cc94bde5-3ac4-45c2-95ee-e55c7ccabf71</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
-    <PackageReference Include="PlaywrightSharp" Version="0.192.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.44.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Integrations.Degiro\Integrations.Degiro.csproj" />

--- a/DegiroPitGenerator/Properties/launchSettings.json
+++ b/DegiroPitGenerator/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "DegiroPitGenerator": {
       "commandName": "Project",
-      "commandLineArgs": "2020"
+      "commandLineArgs": "2024"
     }
   }
 }

--- a/DegiroPitGenerator/appsettings.json
+++ b/DegiroPitGenerator/appsettings.json
@@ -50,8 +50,8 @@
     "ReportsIsoLanguageCode": "pl-PL"
   },
   "DegiroCsvOverride": {
-    "UseLocalCsvs": false,
-    "TransactionsCsvPath": "",
-    "CashOperationsCsvPath": ""
+    "UseLocalCsvs": true,
+    "TransactionsCsvPath": "./Transactions.csv",
+    "CashOperationsCsvPath": "./Account.csv"
   }
 }

--- a/Extensions/Extensions.csproj
+++ b/Extensions/Extensions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/Integrations.Degiro/Adapters/TransactionAdapter.cs
+++ b/Integrations.Degiro/Adapters/TransactionAdapter.cs
@@ -32,7 +32,6 @@ namespace Integrations.Degiro.Adapters
             foreach (var degiroTransaction in degiroTransactions.OrderBy(_ => DateTime.Parse(_.Date, _datesCultureInfo)).ThenBy(_ => TimeSpan.Parse(_.Time)).GroupBy(_ => _.TransactionId))
             {
                 var feeSum = degiroTransaction.Sum(_ => Math.Abs(_.FeeAmount ?? 0));
-
                 //The Distinct().Single() confirms that all dates are the same within TransactionId
                 yield return new Transaction
                 {
@@ -58,7 +57,10 @@ namespace Integrations.Degiro.Adapters
 
         private Country SelectCountry(string stockExchangeName)
         {
-            return _configuration.Domain.StockCountriesMapping[stockExchangeName];
+            var result = _configuration.Domain.StockCountriesMapping[stockExchangeName];
+            if (result == default)
+                throw new Exception($"Stock exchange country mapping for {stockExchangeName} not found");
+            return result;
         }
     }
 }

--- a/Integrations.Degiro/Csv.cs
+++ b/Integrations.Degiro/Csv.cs
@@ -42,13 +42,16 @@ namespace Integrations.Degiro
             if (records is List<CsvTransaction> transactions)
                 //There are some artifact rows in Degiro transaction csv
                 transactions.RemoveAll(_ => _.TransactionId == "");
-            else if(records is IEnumerable<CsvCashOperation> cashOperations)
-            {
-                //CsvReader does not support polish culture info, so we need to manually adjust it
-                cashOperations.ForEach(_ => _.BalanceAmount /= 100m);
-                cashOperations.ForEach(_ => _.ChangeAmount /= 100m);
-                cashOperations.ForEach(_ => _.ExchangeRate /= 10000m);
-            }
+
+            //Commented out, because as of 04.2025 degiro outputs CsvReader compatibile output 
+            //for polish account with language set to english
+                // else if(records is IEnumerable<CsvCashOperation> cashOperations)
+                // {
+                //         //CsvReader does not support polish culture info, so we need to manually adjust it
+                //         cashOperations.ForEach(_ => _.ExchangeRate /= 10000m);
+                //         cashOperations.ForEach(_ => _.BalanceAmount /= 100m);
+                //         cashOperations.ForEach(_ => _.ChangeAmount /= 100m);
+                // }
 
             return records;
         }

--- a/Integrations.Degiro/Integration.cs
+++ b/Integrations.Degiro/Integration.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using System.Threading.Tasks;
 using Integrations.Degiro.Models;
 using Integrations.Degiro.Models.Configuration;
 using Newtonsoft.Json.Linq;
@@ -9,8 +10,8 @@ namespace Integrations.Degiro
 {
     public interface IIntegration
     {
-        ICsv<CsvTransaction> GetTransactions();
-        ICsv<CsvCashOperation> GetCashOperations(int year);
+        Task<ICsv<CsvTransaction>> GetTransactionsAsync();
+        Task<ICsv<CsvCashOperation>> GetCashOperationsAsync(int year);
     }
 
     internal class Integration : IIntegration
@@ -25,44 +26,51 @@ namespace Integrations.Degiro
             _configuration = configuration;
             _jSessionId = jSessionId;
             _client = new RestClient();
-            _accountId = GetAccountId();
+            _accountId = GetAccountIdAsync().GetAwaiter().GetResult();
 
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         }
 
-        public ICsv<CsvCashOperation> GetCashOperations(int year)
+        public async Task<ICsv<CsvCashOperation>> GetCashOperationsAsync(int year)
         {
             var startDate = new DateTime(year, 1, 1);
             var endDate = new DateTime(year, 12, 31);
 
-            return DownloadCsv<CsvCashOperation>(_configuration.CashOperationsUrl, startDate, endDate);
+            return await DownloadCsvAsync<CsvCashOperation>(_configuration.CashOperationsUrl, startDate, endDate);
         }
 
-        public ICsv<CsvTransaction> GetTransactions()
+        public async Task<ICsv<CsvTransaction>> GetTransactionsAsync()
         {
             //This date needs to be before 1st transaction.
             //Since Degiro was founded in 2008 I assume that there should be no transaction before that.
             var startDate = new DateTime(2007, 1, 1);
-
             var endDate = DateTime.Now.AddDays(1);
 
-            return DownloadCsv<CsvTransaction>(_configuration.TransactionsUrl, startDate, endDate);
+            return await DownloadCsvAsync<CsvTransaction>(_configuration.TransactionsUrl, startDate, endDate);
         }
 
-        private ICsv<T> DownloadCsv<T>(string url, DateTime startDate, DateTime endDate)
+        private async Task<ICsv<T>> DownloadCsvAsync<T>(string url, DateTime startDate, DateTime endDate)
         {
             const string dateFormat = "dd'%2F'MM'%2F'yyyy";
 
-            var request = new RestRequest(
-                string.Format(url, _accountId, _jSessionId, startDate.ToString(dateFormat), endDate.ToString(dateFormat)));
+            var formattedUrl = string.Format(url, _accountId, _jSessionId, startDate.ToString(dateFormat), endDate.ToString(dateFormat));
+            var request = new RestRequest(formattedUrl);
 
-            return new Csv<T>(Encoding.UTF8.GetString(_client.DownloadData(request)));
+            var data = await _client.DownloadDataAsync(request);
+            return new Csv<T>(Encoding.UTF8.GetString(data));
         }
 
-        private string GetAccountId()
+        private async Task<string> GetAccountIdAsync()
         {
             var request = new RestRequest(string.Format(_configuration.AccountUrl, _jSessionId));
-            return JObject.Parse(_client.Execute(request).Content)["data"]["intAccount"].ToString();
+            var response = await _client.ExecuteAsync(request);
+
+            if (!response.IsSuccessful)
+            {
+                throw new Exception($"Failed to get account ID: {response.ErrorMessage}");
+            }
+
+            return JObject.Parse(response.Content!)["data"]!["intAccount"]!.ToString();
         }
     }
 }

--- a/Integrations.Degiro/IntegrationFactory.cs
+++ b/Integrations.Degiro/IntegrationFactory.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
 using Integrations.Degiro.Models.Configuration;
-using PlaywrightSharp;
+using Microsoft.Playwright;
 
 namespace Integrations.Degiro
 {
@@ -17,22 +17,27 @@ namespace Integrations.Degiro
         public async Task<IIntegration> Create()
         {
             using var playwright = await Playwright.CreateAsync();
-            await using var browser = await playwright.Chromium.LaunchAsync();
-            var page = await browser.NewPageAsync();
+            await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+            {
+                Headless = true
+            });
 
-            await page.GoToAsync(_configuration.Login.LoginUrl);
+            var context = await browser.NewContextAsync();
+            var page = await context.NewPageAsync();
 
-            await page.WaitForLoadStateAsync(LifecycleEvent.DOMContentLoaded);
+            await page.GotoAsync(_configuration.Login.LoginUrl);
+
+            await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
 
             await page.FillAsync($"xpath={_configuration.Login.XPaths.UsernameTextBox}", _configuration.Credentials.Username);
             await page.FillAsync($"xpath={_configuration.Login.XPaths.PasswordTextBox}", _configuration.Credentials.Password);
             await page.ClickAsync($"xpath={_configuration.Login.XPaths.LoginButton}");
 
-            //It takes some time to get the right cookie back, so let's wait for page to fully redirect
-            await page.WaitForLoadStateAsync(LifecycleEvent.Networkidle);
+            // Wait until network activity settles after login
+            await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-            var cookies = await page.Context.GetCookiesAsync(page.Url);
-            var jSessionId = cookies.Single(_ => _.Name == _configuration.Login.SessionCookieName).Value;
+            var cookies = await context.CookiesAsync();
+            var jSessionId = cookies.Single(c => c.Name == _configuration.Login.SessionCookieName).Value;
 
             return new Integration(_configuration.Requests, jSessionId);
         }

--- a/Integrations.Degiro/Integrations.Degiro.csproj
+++ b/Integrations.Degiro/Integrations.Degiro.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="26.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="PlaywrightSharp" Version="0.192.0" />
-    <PackageReference Include="RestSharp" Version="106.11.7" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="RestSharp" Version="111.0.0" />    
+    <PackageReference Include="Microsoft.Playwright" Version="1.44.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Integrations.Nbp/Integrations.Nbp.csproj
+++ b/Integrations.Nbp/Integrations.Nbp.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RestSharp" Version="106.11.7" />
+    <PackageReference Include="RestSharp" Version="111.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Models/Models.csproj
+++ b/Models/Models.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/PolishPitGenerator/PitProvider.cs
+++ b/PolishPitGenerator/PitProvider.cs
@@ -43,8 +43,6 @@ namespace PolishPitGenerator
 
         private Report GenerateReport(List<FinancialInstrumentBalance> financialInstrumentBalances, List<PitDividend> dividends, List<PitFee> fees)
         {
-            var test = financialInstrumentBalances.Sum(fib => fib.AllUnitsClosedInYear.Sum(au => au.GetIncome())).Round2() - financialInstrumentBalances.Sum(fib => fib.AllUnitsClosedInYear.Sum(au =>  au.GetTotalCost())).Round2();
-            
             return new Report
             {
                 GeneratorVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString(),

--- a/PolishPitGenerator/PitProvider.cs
+++ b/PolishPitGenerator/PitProvider.cs
@@ -43,6 +43,8 @@ namespace PolishPitGenerator
 
         private Report GenerateReport(List<FinancialInstrumentBalance> financialInstrumentBalances, List<PitDividend> dividends, List<PitFee> fees)
         {
+            var test = financialInstrumentBalances.Sum(fib => fib.AllUnitsClosedInYear.Sum(au => au.GetIncome())).Round2() - financialInstrumentBalances.Sum(fib => fib.AllUnitsClosedInYear.Sum(au =>  au.GetTotalCost())).Round2();
+            
             return new Report
             {
                 GeneratorVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString(),
@@ -61,9 +63,9 @@ namespace PolishPitGenerator
                         .Select(g => new PitZG
                     {
                         Country = g.Key,
-                        C3_32 = g.Sum(fib => fib.AllUnitsClosedInYear.Sum(au => au.GetProfit())).Round2(),
+                        C3_29 = g.Sum(fib => fib.AllUnitsClosedInYear.Sum(au => au.GetProfit())).Round2(),
                         //Assumging there was no Tax taken from the transaction profit
-                        C3_33 = 0m
+                        C3_30 = 0m
                     })
                 },
                 ConsolidatedReport = new ConsolidatedReport

--- a/PolishPitGenerator/PolishPitGenerator.csproj
+++ b/PolishPitGenerator/PolishPitGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PolishPitGenerator/Reports/Models/Pit38Report.cs
+++ b/PolishPitGenerator/Reports/Models/Pit38Report.cs
@@ -4,11 +4,31 @@ namespace PolishPitGenerator.Reports.Models
 {
     public class Pit38Report
     {
-        public decimal C22 { get; set; }
-        public decimal C23 { get; set; }
-        public decimal G45 { get; set; }
+        //Comments and fields are based on 2024 PIT-38 form version
+
+        //DOCHODY / STRATY – ART. 30B UST. 1 USTAWY
+
+        //Inne przychody - Przychód
+        public decimal C22 { get; set; } 
+
+        //Inne przychody - Koszty uzyskania przychodów
+        public decimal C23 { get; set; } 
+
+        //G. PODATEK DO ZAPŁATY / NADPŁATA
+
+        //Zryczałtowany podatek obliczony od przychodów (dochodów),
+        //o których mowa w art. 30a ust. 1 pkt 1–5 ustawy, 
+        //uzyskanych poza granicami Rzeczypospolitej Polskiej
+        public decimal G45 { get; set; } 
+
+        //Podatek zapłacony za granicą, 
+        //o którym mowa w art. 30a ust. 9 ustawy (przeliczony na złote)
         public decimal G46 { get; set; }
+
+        //Różnica między zryczałtowanym podatkiem a podatkiem zapłaconym za granicą (po zaokrągleniu do pełnych złotych)
         public decimal G47 { get; set; }
+
+        
         public IEnumerable<PitZG> PitZGs { get; set; }
     }
 }

--- a/PolishPitGenerator/Reports/Models/PitZG.cs
+++ b/PolishPitGenerator/Reports/Models/PitZG.cs
@@ -4,8 +4,19 @@ namespace PolishPitGenerator.Reports.Models
 {
     public class PitZG
     {
+        //Comments and fields are based on 2024 PIT-ZG form version
+
+        //B. DODATKOWE INFORMACJE
+
+        //6. Państwo uzyskania dochodu / przychodu 
         public Country Country { get; internal set; }
-        public decimal C3_32 { get; internal set; }
-        public decimal C3_33 { get; internal set; }
+
+        //C.3. DOCHODY I PODATEK ROZLICZANE W ZEZNANIU PODATKOWYM PIT-38
+
+        //Dochód, o którym mowa w art. 30b ust. 5a i 5b ustawy 
+        public decimal C3_29 { get; internal set; }
+
+        //Podatek zapłacony za granicą od dochodów z poz. 291) 
+        public decimal C3_30 { get; internal set; }
     }
 }


### PR DESCRIPTION
- Switched from target framework netcoreapp3.1 to net6.0
- Switched from PlaywrightSharp to Microsoft.Playwright
- Updated Microsoft.Extensions packages
- AI generated necessary adjustments for code to compile 
- Changes tested on DegiroCsvOverride mode on MacOs with Apple Silicon on VS Code
- Updated tax field codenames for 2024
- Included comments for tax fields for future proofing
- Added fix because csv reader was now properly reading values, so dividing dividend values by 100 was breaking output